### PR TITLE
Fix cleartext traffic issue with newer devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
          location permissions for the 'MyLocation' functionality.
     -->
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
Android 9 and above have disabled support for cleartext / HTTP traffic by default.

Twitter returns user profile picture URLs with `http://`, so Picasso will fail to download them if you're using a new-ish emulator.

To fix this you can add `android:usesCleartextTraffic="true"` (or, more appropriate, force `https://` when parsing the profile pic URL out of the Search Tweets response).